### PR TITLE
[CZB-505] fix bug checkOpenStarterPack always return false

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
   "dev": {},
   "bsctest": {
-    "cryptoZombie": "0x0e0892Ffa21D698e116DeB84d1B0b7cA4c8B683E",
-    "marketplace": "0x3eaC9731C9E6c7AE8dF7983ce323a966779836B4",
+    "cryptoZombie": "0x94BAF8283959BE344cdbBde203eA79880DE66600",
+    "marketplace": "0x9C4bA7B81404567fa2F3cD28B4e9b9252476E564",
     "btcs": "0xEcF3F554f58e9eF274aa3DF60f9c9ca3Ba156073"
   },
   "rinkeby": {},

--- a/contracts/GiftPack.sol
+++ b/contracts/GiftPack.sol
@@ -5,18 +5,18 @@ import "./ZombieAttack.sol";
 
 contract GiftPack is ZombieAttack {
     uint public constant STATER_ZOMBIE_COUNT = 3;
-    mapping(address => bool) seenWalletOpenStaterPack;
+    mapping(address => bool) public seenWalletOpenStaterPack;
 
     event OpenStaterPack(address indexed owner, Zombie[] zombies);
 
     constructor(address _token) ZombieAttack(_token) {}
 
-    function checkOpenStarterPack() public view returns (bool) {
-        return seenWalletOpenStaterPack[msg.sender];
+    function checkOpenStarterPack(address _address) public view returns (bool) {
+        return seenWalletOpenStaterPack[_address];
     }
 
     function openStaterPack() public {
-        require(!checkOpenStarterPack());
+        require(!checkOpenStarterPack(msg.sender));
         seenWalletOpenStaterPack[msg.sender] = true;
 
         emit OpenStaterPack(msg.sender, createManyZombie(STATER_ZOMBIE_COUNT));

--- a/test/Giftpack.test.js
+++ b/test/Giftpack.test.js
@@ -16,7 +16,7 @@ describe('GiftPack', () => {
 
   describe('openStaterPack', async () => {
     it('Should return false if new wallet checkOpenStarterPack', async () => {
-      const isOpenStaterPack = await mainSmartContract.connect(addr1).checkOpenStarterPack();
+      const isOpenStaterPack = await mainSmartContract.checkOpenStarterPack(addr1.address);
       expect(isOpenStaterPack).to.be.false;
     });
 
@@ -26,7 +26,7 @@ describe('GiftPack', () => {
 
     it('Should return true if wallet already opened stater pack', async () => {
       await mainSmartContract.connect(addr1).openStaterPack();
-      expect(await mainSmartContract.connect(addr1).checkOpenStarterPack()).to.be.true;
+      expect(await mainSmartContract.checkOpenStarterPack(addr1.address)).to.be.true;
     });
 
     it('Should throw error openStaterPack if wallet already opened stater pack', async () => {


### PR DESCRIPTION
## Ticket
- https://btc-studio.larksuite.com/wiki/wikusV4NuHyC9QO3IkAFpMHIpLo?table=tblKD8AahdZ20gue&view=vewrDFMLjZ&record=recJ7hz3nq&field=fldi63oypS

Nội dung bug: hàm checkOpenStarterPack luôn return false
Nguyên nhân: hàm checkOpenStarterPack là hàm view => msg.sender sẽ là null => hàm này luôn return false

## Self test
- [x] Pass 4 unit test
- [x] Self test trên BSC scan

## Note
- No